### PR TITLE
Add access rules and update manifest

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -4,8 +4,9 @@
     "version": "1.0",
     "depends": ["base", "sale", "hr", "product"],
     "data": [
+        "security/ir.model.access.csv",
         "views/obras_views.xml",
-        "views/registro_diario_views.xml"
+        "views/registro_diario_views.xml",
     ],
     "installable": True,
 }

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_obras_obra_user,obras.obra,model_obras_obra,base.group_user,1,1,1,1
+access_obras_registro_material_user,obras.registro_material,model_obras_registro_material,base.group_user,1,1,1,1
+access_obras_registro_diario_user,obras.registro_diario,model_obras_registro_diario,base.group_user,1,1,1,1


### PR DESCRIPTION
## Summary
- grant users access to Obra and Registro models via CSV
- include the new access file in the manifest

## Testing
- `python -m py_compile obra.py registro_diario.py __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_685c08b043b48327bfd560c582d0ac4c