### PR TITLE
Add report model for weekly metrics

### DIFF
--- a/docs/generate_report.py
+++ b/docs/generate_report.py
@@ -1,0 +1,69 @@
+import datetime
+
+# Datos base proporcionados
+DATA = {
+    'Fecha': '2025-06-26',
+    'Bolsas_fibra': 231,
+    'Adhesivo_bidones': 48,
+    'Volumen_aplicado_m2': 2654,
+    'Obras_iniciadas_semana': 13,
+    'Kg_descartes_semana': 446.0,
+    'Tiempo_promedio_jornada_horas': 5.33,
+    'Cantidad_registros_diarios': 18,
+}
+
+# Indicadores adicionales calculados
+def indicadores_adicionales(data):
+    vol = data['Volumen_aplicado_m2']
+    fibra_por_m2 = data['Bolsas_fibra'] / vol
+    adhesivo_por_m2 = data['Adhesivo_bidones'] / vol
+    descarte_por_m2 = data['Kg_descartes_semana'] / vol
+    horas_totales = data['Tiempo_promedio_jornada_horas'] * data['Cantidad_registros_diarios']
+    return {
+        'Fibra por m2': round(fibra_por_m2, 4),
+        'Adhesivo por m2': round(adhesivo_por_m2, 4),
+        'Descarte por m2 (kg)': round(descarte_por_m2, 4),
+        'Horas totales estimadas': round(horas_totales, 2),
+    }
+
+# Generador de barras ASCII
+def barra(value, max_value, width=30):
+    proportion = value / max_value if max_value else 0
+    fill = int(proportion * width)
+    return '[' + '#' * fill + '-' * (width - fill) + ']'
+
+def generar_reporte(data):
+    lines = []
+    lines.append(f"Reporte Semanal - Fecha: {data['Fecha']}")
+    lines.append('')
+    lines.append('Indicadores Principales:')
+
+    valores = {
+        'Bolsas de fibra usadas': data['Bolsas_fibra'],
+        'Adhesivo (bidones)': data['Adhesivo_bidones'],
+        'Volumen aplicado (m2)': data['Volumen_aplicado_m2'],
+        'Obras iniciadas': data['Obras_iniciadas_semana'],
+        'Kg de descarte': data['Kg_descartes_semana'],
+        'Tiempo promedio jornada (h)': data['Tiempo_promedio_jornada_horas'],
+        'Cantidad registros diarios': data['Cantidad_registros_diarios'],
+    }
+
+    max_val = max(valores.values())
+    for nombre, valor in valores.items():
+        lines.append(f"- {nombre}: {valor}")
+        lines.append('  ' + barra(valor, max_val))
+
+    lines.append('')
+    lines.append('Indicadores Adicionales:')
+    extras = indicadores_adicionales(data)
+    for nombre, valor in extras.items():
+        lines.append(f"- {nombre}: {valor}")
+
+    return '\n'.join(lines)
+
+if __name__ == '__main__':
+    contenido = generar_reporte(DATA)
+    ruta = 'docs/reporte_semanal_2025-06-26.txt'
+    with open(ruta, 'w') as f:
+        f.write(contenido + "\n")
+    print(f'Reporte generado en {ruta}')

--- a/docs/reporte_semanal_2025-06-26.txt
+++ b/docs/reporte_semanal_2025-06-26.txt
@@ -1,0 +1,23 @@
+Reporte Semanal - Fecha: 2025-06-26
+
+Indicadores Principales:
+- Bolsas de fibra usadas: 231
+  [##----------------------------]
+- Adhesivo (bidones): 48
+  [------------------------------]
+- Volumen aplicado (m2): 2654
+  [##############################]
+- Obras iniciadas: 13
+  [------------------------------]
+- Kg de descarte: 446.0
+  [#####-------------------------]
+- Tiempo promedio jornada (h): 5.33
+  [------------------------------]
+- Cantidad registros diarios: 18
+  [------------------------------]
+
+Indicadores Adicionales:
+- Fibra por m2: 0.087
+- Adhesivo por m2: 0.0181
+- Descarte por m2 (kg): 0.168
+- Horas totales estimadas: 95.94


### PR DESCRIPTION
## Summary
- add a simple Python script that generates a weekly report
- include the resulting sample report for 2025-06-26

## Testing
- `python3 docs/generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_685d5e4fad6083279701f3f81f9510bd